### PR TITLE
Add clickable markers mode with parent signer sync

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -407,6 +407,7 @@ const App = () => {
 
 	const [inputtedLicenseKey, setInputtedLicenseKey] = useState(null);
 	const [initialAnnotations, setInitialAnnotations] = useState([]);
+	const [initialSigners, setInitialSigners] = useState([]);
 	const { files, setFiles } = useContext(FilesContext);
 
 	const [fileNames, setFileNames] = useState([]);
@@ -500,6 +501,9 @@ const App = () => {
 			}
 			if (typeof event.data === 'object' && !!event.data.initialAnnotations) {
 				setInitialAnnotations(event.data.initialAnnotations);
+			}
+			if (typeof event.data === 'object' && !!event.data.initialSigners) {
+				setInitialSigners(event.data.initialSigners);
 			}
 			if (typeof event.data === 'object' && !!event.data.modifiedUiElements) {
 				setModifiedUiElements(event.data.modifiedUiElements);
@@ -1916,7 +1920,18 @@ const App = () => {
 				source: null
 			};
 		}
-		
+
+	};
+
+	const onSaveClickableMarkers = (updatedSigners, annotations) => {
+		setInitialSigners(updatedSigners);
+		if (typeof window !== 'undefined' && window.parent) {
+			window.parent.postMessage({
+				type: 'clickable-markers-save',
+				signers: updatedSigners,
+				annotations
+			}, '*');
+		}
 	};
 
 	const onMoveAnnotation = (data) => {
@@ -2214,11 +2229,11 @@ const App = () => {
 						customData={customData}
 						onEnableClickTagMode={onEnableClickTagMode}
 						pdfProxyObj={pdfProxyObj}
-						onClickField={onClickField}
-						editorMode={editorMode}
-						showFullScreenSearch={showFullScreenSearch()}
-						tools={tools}
-						aiLimitReached={aiLimitReached}
+                                          onClickField={onClickField}
+                                          editorMode={editorMode}
+                                          showFullScreenSearch={showFullScreenSearch()}
+                                          tools={tools}
+                                          aiLimitReached={aiLimitReached}
 						onNoToAiWarning={onNoToAiWarning}
 						aiDocHash={aiDocHash}
 						currentAiDocHash={currentAiDocHash}
@@ -2238,11 +2253,13 @@ const App = () => {
 						matchesCount={matchesCount}
 						matchWholeWord={matchWholeWord}
 						onChange={onSearchText}
-						onFindCitation={onSearchText}
-						showSearch={showSearch}
-						caseSensitive={caseSensitive}
-						onToggleCaseSensitive={onToggleCaseSensitive}
-					/>
+                                          onFindCitation={onSearchText}
+                                          showSearch={showSearch}
+                                          caseSensitive={caseSensitive}
+                                          onToggleCaseSensitive={onToggleCaseSensitive}
+                                          initialSigners={initialSigners}
+                                          onSaveClickableMarkers={onSaveClickableMarkers}
+                                  />
 				</div>
 			</div>
 		</>

--- a/src/components/Searchbar/TagSection/ClickableMarkers.js
+++ b/src/components/Searchbar/TagSection/ClickableMarkers.js
@@ -62,14 +62,26 @@ const nextBtn = css`
   cursor: pointer;
 `;
 
+const saveBtn = css`
+  display: flex;
+  padding: 0 8px;
+  background: #6ce906;
+  border-radius: 4px;
+  border: none;
+  align-items: center;
+  cursor: pointer;
+`;
+
 const ClickableMarkers = ({
-	showFullScreenSearch,
-	showSearch,
+     showFullScreenSearch,
+     showSearch,
   onClickField,
   onBack,
   onNext,
   signers,
-  forceRefreshView
+  forceRefreshView,
+  showNavigation = true,
+  onSave
 }) => {
 
 	const { t } = useTranslation();
@@ -78,10 +90,10 @@ const ClickableMarkers = ({
   // const [activeSignerId, setActiveSignerId] = useState(signers[0]?.id);
 
   useEffect(() => {
-    if (!activeSignerId) {
+    if (!activeSignerId && signers?.length) {
       setActiveSignerId(signers[0]?.id);
     }
-  }, signers);
+  }, [signers, activeSignerId, setActiveSignerId]);
 
 	const getWrapperClass = () => {
 		if (showFullScreenSearch) {
@@ -127,9 +139,15 @@ const ClickableMarkers = ({
         <button css={tagBtnStyle} onClick={() => onClickField('Email', false, activeSignerId)}>{t("Email")}</button>
         <button css={tagBtnStyle} onClick={() => onClickField('Date', false, activeSignerId)}>{t("Date")}</button>
       </div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', padding: '8px 4px', background: '#f1f3f5' }}>
-        <button css={backBtn} onClick={onBack}><Icon src={ChevronLeft} alt={t("Back")} /><div>{t("Back")}</div></button>
-        <button css={nextBtn} onClick={onNext}><div>{t("Next")}</div><Icon src={ChevronRight} alt={t("Next")} /></button>
+      <div style={{ display: 'flex', justifyContent: showNavigation ? 'space-between' : 'flex-end', padding: '8px 4px', background: '#f1f3f5' }}>
+        {showNavigation ? (
+          <>
+            <button css={backBtn} onClick={onBack}><Icon src={ChevronLeft} alt={t("Back")} /><div>{t("Back")}</div></button>
+            <button css={nextBtn} onClick={onNext}><div>{t("Next")}</div><Icon src={ChevronRight} alt={t("Next")} /></button>
+          </>
+        ) : (
+          <button css={saveBtn} onClick={onSave}><div>{t("Save")}</div></button>
+        )}
       </div>
     </div>
   );

--- a/src/components/Searchbar/index.js
+++ b/src/components/Searchbar/index.js
@@ -139,7 +139,9 @@ const SearchBar = ({
 	onNoToAiWarning,
 	conversation,
 	setConversation,
-	forceRefreshView
+	forceRefreshView,
+	initialSigners,
+	onSaveClickableMarkers
 }) => {
 
 	const { hasValidSubscription } = useUserData();
@@ -217,7 +219,7 @@ const SearchBar = ({
 		);
 	}
 
-	if (editorMode === 'tag') {
+	if (editorMode === 'tag' || editorMode === 'add-clickable-markers') {
 		return (
 			<TagSection
 				forceRefreshView={forceRefreshView}
@@ -228,6 +230,9 @@ const SearchBar = ({
 				showFullScreenSearch={showFullScreenSearch}
 				onClickField={onClickField}
 				showSearch={showSearch}
+				editorMode={editorMode}
+				initialSigners={initialSigners}
+				onSaveClickableMarkers={onSaveClickableMarkers}
 			/>
 		);
 	}


### PR DESCRIPTION
## Summary
- add support for loading initial signers from parent messages and posting results back when saving markers
- extend the search bar tag section to handle a new `add-clickable-markers` mode that jumps straight to clickable markers with a save action
- update the clickable markers UI to support a standalone mode with a save button

## Testing
- npm run lint *(fails: existing lint issues in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb58b0e288323a8a4998062fe3a9f