### PR TITLE
Trigger text edit mode when Add markers panel regains focus

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2229,9 +2229,10 @@ const App = () => {
 							onEditOriginalTextSelected={onEditOriginalTextSelected}
 							storage={storage}
 							initialAnnotations={initialAnnotations}
-							onTagClicked={onTagClicked}
-							activeToolbarItemRef={activeToolbarItemRef}
-							onAnnotationFocus={onAnnotationFocus}
+                                                        onTagClicked={onTagClicked}
+                                                        onEnableTextEditMode={onEnableTextEditMode}
+                                                        activeToolbarItemRef={activeToolbarItemRef}
+                                                        onAnnotationFocus={onAnnotationFocus}
 							annotationColor={annotationColor}
 							moveAnnotation={onMoveAnnotation}
 							removeAnnotation={onRemoveAnnotation}

--- a/src/PdfViewer.js
+++ b/src/PdfViewer.js
@@ -71,8 +71,9 @@ export const PdfViewer = ({
 	setFileLoadFailError,
 	setDocumentLoading,
 	isSandbox,
-	updateCurrentScale,
-	onTagClicked
+        updateCurrentScale,
+        onTagClicked,
+        onEnableTextEditMode
 }) => {
 
 	const panelSpaceUsed = () => {
@@ -88,7 +89,12 @@ export const PdfViewer = ({
 
 	const { activeSignerId } = useContext(AnnotationsContext);
 
-	const hasWatermarkAdded = useRef(false);
+        const hasWatermarkAdded = useRef(false);
+        const enableTextEditModeRef = useRef(onEnableTextEditMode);
+
+        useEffect(() => {
+                enableTextEditModeRef.current = onEnableTextEditMode;
+        }, [onEnableTextEditMode]);
 
 	const cleanupDocument = async () => {
 		pdfViewerRef.current?.setDocument(null);
@@ -302,23 +308,29 @@ export const PdfViewer = ({
 
 
 	useEffect(() => {
-		function handleVisibilityChange() {
-			if (document.hidden) {
-				// Page is now hidden
-			}
-			else {
-				// Page is now visible
+                function handleVisibilityChange() {
+                        if (document.hidden) {
+                                // Page is now hidden
+                        }
+                        else {
+                                // Page is now visible
 
-				// You can put your logic here to re-render the PDF or perform some other actions
-				// For example, you might call a function to reload the PDF:
-				const targetContainer = viewerContainerRef1.current;
-				applyDocument(targetContainer);
-			}
-		}
-	
-		document.addEventListener('visibilitychange', handleVisibilityChange);
-		return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
-	}, [modifiedFiles, files, activeSignerId]);
+                                // You can put your logic here to re-render the PDF or perform some other actions
+                                // For example, you might call a function to reload the PDF:
+                                console.log('Hello focus');
+                                const targetContainer = viewerContainerRef1.current;
+                                if (targetContainer) {
+                                        applyDocument(targetContainer);
+                                }
+                                if (rightPanelEnabled && editorMode === 'add-clickable-markers') {
+                                        enableTextEditModeRef.current?.();
+                                }
+                        }
+                }
+
+                document.addEventListener('visibilitychange', handleVisibilityChange);
+                return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+        }, [modifiedFiles, files, activeSignerId, rightPanelEnabled, editorMode]);
 
 	const width = () => {
 		if (!tools?.general?.includes('thumbnails')) {


### PR DESCRIPTION
## Summary
- log when the PDF viewer regains focus via the existing visibilitychange handler
- re-enable text edit mode on focus when the Add markers panel is visible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d68e98da84832398370a3e38f7735d