### PR TITLE
Fix active signer selection for initial annotations

### DIFF
--- a/src/components/Searchbar/TagSection/ClickableMarkers.js
+++ b/src/components/Searchbar/TagSection/ClickableMarkers.js
@@ -90,7 +90,13 @@ const ClickableMarkers = ({
   // const [activeSignerId, setActiveSignerId] = useState(signers[0]?.id);
 
   useEffect(() => {
-    if (!activeSignerId && signers?.length) {
+    if (!signers?.length) {
+      return;
+    }
+
+    const hasActiveSigner = signers.some((signer) => signer.id === activeSignerId);
+
+    if (!hasActiveSigner) {
       setActiveSignerId(signers[0]?.id);
     }
   }, [signers, activeSignerId, setActiveSignerId]);


### PR DESCRIPTION
## Summary
- ensure the active signer selection updates when a new signer list is provided so existing clickable markers render

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d711459b488323a4d2d0a9f0390998