### PR TITLE
Add editable text modal for name/email/date/initials tags

### DIFF
--- a/src/Contexts/ModalProvider.js
+++ b/src/Contexts/ModalProvider.js
@@ -2,6 +2,7 @@ import { useContext, useState } from 'preact/hooks';
 import { createContext } from 'preact';
 import ConfirmationModal from '../components/ConfirmationModal';
 import SignatureModal from '../components/SignatureModal';
+import TextTagModal from '../components/TextTagModal';
 import AuthModal from '../components/AuthModal';
 import SettingsModal from '../components/SettingsModal';
 
@@ -14,11 +15,13 @@ export const ModalProvider = ({ children }) => {
 	const [isAuthVisible, setIsAuthVisible] = useState(false);
 	const [message, setMessage] = useState('');
 	const [onConfirmCallback, setOnConfirmCallback] = useState(null);
-	const [isSignatureVisible, setIsSignatureVisible] = useState(false);
-	const [isSettingsVisible, setIsSettingsVisible] = useState(false);
-	const [modifiedUiElements, setModifiedUiElements] = useState(null);
-	const [showLogin, setShowLogin] = useState(false);
-	const [locale, setLocale] = useState("");
+        const [isSignatureVisible, setIsSignatureVisible] = useState(false);
+        const [isSettingsVisible, setIsSettingsVisible] = useState(false);
+        const [modifiedUiElements, setModifiedUiElements] = useState(null);
+        const [showLogin, setShowLogin] = useState(false);
+        const [locale, setLocale] = useState("");
+        const [isTextTagVisible, setIsTextTagVisible] = useState(false);
+        const [textTagConfig, setTextTagConfig] = useState(null);
 
 	const showModal = (msg, onConfirm) => {
 		setMessage(msg);
@@ -26,12 +29,18 @@ export const ModalProvider = ({ children }) => {
 		setOnConfirmCallback(() => onConfirm); // Storing the callback
 	};
 
-	const showSignatureModal = (name, onConfirm) => {
-		setMessage(name);
-		window.parent.postMessage({ type: 'annotation-modal-open-change', message: true }, '*');
-		setIsSignatureVisible(true);
-		setOnConfirmCallback(() => onConfirm); // Storing the callback
-	};
+        const showSignatureModal = (name, onConfirm) => {
+                setMessage(name);
+                window.parent.postMessage({ type: 'annotation-modal-open-change', message: true }, '*');
+                setIsSignatureVisible(true);
+                setOnConfirmCallback(() => onConfirm); // Storing the callback
+        };
+
+        const showTextTagModal = (config) => {
+                window.parent.postMessage({ type: 'annotation-modal-open-change', message: true }, '*');
+                setTextTagConfig(config);
+                setIsTextTagVisible(true);
+        };
 
 	const [authMessage, setAuthMessage] = useState("");
 
@@ -50,10 +59,16 @@ export const ModalProvider = ({ children }) => {
 		setIsVisible(false);
 	};
 
-	const hideSignatureModal = () => {
-		window.parent.postMessage({ type: 'annotation-modal-open-change', message: false }, '*');
-		setIsSignatureVisible(false);
-	};
+        const hideSignatureModal = () => {
+                window.parent.postMessage({ type: 'annotation-modal-open-change', message: false }, '*');
+                setIsSignatureVisible(false);
+        };
+
+        const hideTextTagModal = () => {
+                window.parent.postMessage({ type: 'annotation-modal-open-change', message: false }, '*');
+                setIsTextTagVisible(false);
+                setTextTagConfig(null);
+        };
 	
 	const hideAuthModal = () => {
 		setIsAuthVisible(false);
@@ -64,16 +79,22 @@ export const ModalProvider = ({ children }) => {
 		setIsSettingsVisible(false);
 	}
 
-	return (
-		<ModalContext.Provider value={{ showModal, showSignatureModal, hideModal, setModifiedUiElements, showAuthModal, showSettingsModal }}>
+        return (
+                <ModalContext.Provider value={{ showModal, showSignatureModal, showTextTagModal, hideModal, hideSignatureModal, setModifiedUiElements, showAuthModal, showSettingsModal }}>
 			{isVisible && <ConfirmationModal onConfirm={onConfirmCallback} message={message} onClose={hideModal} />}
 			{isAuthVisible && <AuthModal message={authMessage} onClose={hideAuthModal} showLogin={showLogin} />}
 			{isSettingsVisible && <SettingsModal locale={locale} onClose={hideSettingsModal} />}
-			{isSignatureVisible && <SignatureModal
-				modifiedUiElements={modifiedUiElements}
-				onConfirm={onConfirmCallback}
-				onClose={hideSignatureModal}
-			                       />}
+                        {isSignatureVisible && <SignatureModal
+                                modifiedUiElements={modifiedUiElements}
+                                onConfirm={onConfirmCallback}
+                                onClose={hideSignatureModal}
+                                               />}
+                        {isTextTagVisible && textTagConfig && (
+                                <TextTagModal
+                                        {...textTagConfig}
+                                        onClose={hideTextTagModal}
+                                />
+                        )}
 			{children}
 		</ModalContext.Provider>
 	);

--- a/src/components/TextTagModal/index.js
+++ b/src/components/TextTagModal/index.js
@@ -1,0 +1,148 @@
+/** @jsxImportSource @emotion/react */
+import { css } from '@emotion/react';
+import { useEffect, useState } from 'preact/hooks';
+import { useTranslation } from 'react-i18next';
+
+const overlayStyle = css`
+  position: fixed;
+  overflow: auto;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 999999;
+`;
+
+const modalContentStyle = css`
+  background-color: white;
+  border-radius: 8px;
+  max-width: 100%;
+  margin-top: 100px;
+`;
+
+const containerStyle = css`
+  padding: 20px;
+  font-family: Arial, sans-serif;
+
+  @media (max-width: 600px) {
+    flex-direction: column;
+  }
+`;
+
+const labelStyle = css`
+  display: block;
+  margin-bottom: 5px;
+`;
+
+const inputStyle = css`
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 16px;
+  font-size: 16px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+`;
+
+const buttonRowStyle = css`
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+`;
+
+const buttonStyle = css`
+  background-color: #4caf50;
+  color: white;
+  padding: 10px 16px;
+  border: none;
+  cursor: pointer;
+  border-radius: 4px;
+  font-size: 14px;
+`;
+
+const secondaryButtonStyle = css`
+  background-color: #767676;
+  color: white;
+  padding: 10px 16px;
+  border: none;
+  cursor: pointer;
+  border-radius: 4px;
+  font-size: 14px;
+`;
+
+const descriptionStyle = css`
+  color: grey;
+  margin-bottom: 16px;
+`;
+
+const titleStyle = css`
+  margin: 0 0 12px;
+`;
+
+const TextTagModal = ({
+  title,
+  description,
+  label,
+  defaultValue = '',
+  confirmLabel,
+  cancelLabel,
+  inputType = 'text',
+  onConfirm,
+  onClose,
+}) => {
+  const { t } = useTranslation();
+  const [value, setValue] = useState(defaultValue ?? '');
+
+  useEffect(() => {
+    setValue(defaultValue ?? '');
+  }, [defaultValue]);
+
+  const handleConfirm = () => {
+    onConfirm?.(value);
+    onClose?.();
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleConfirm();
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onClose?.();
+    }
+  };
+
+  return (
+    <div css={overlayStyle}>
+      <div css={modalContentStyle} style={{ width: 400 }}>
+        <div css={containerStyle}>
+          {title && <h1 css={titleStyle}>{title}</h1>}
+          {description && <p css={descriptionStyle}>{description}</p>}
+          {label && <label css={labelStyle}>{label}</label>}
+          <input
+            css={inputStyle}
+            type={inputType}
+            value={value}
+            onInput={(event) => setValue(event.target.value)}
+            onKeyDown={handleKeyDown}
+            autoFocus
+          />
+          <div css={buttonRowStyle}>
+            <button css={secondaryButtonStyle} onClick={onClose} type="button">
+              {cancelLabel || t('Cancel')}
+            </button>
+            <button css={buttonStyle} onClick={handleConfirm} type="button">
+              {confirmLabel || t('Apply')}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TextTagModal;


### PR DESCRIPTION
## Summary
- introduce a reusable TextTagModal component for editing text tag values before they are placed
- update the modal provider to manage the new text tag modal state alongside the signature modal
- prompt for and persist name, email, initials, and date text defaults so subsequent tag placements skip the modal

## Testing
- npm test -- --watchAll=false *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68d7f04ee51083238d1785434f7d2e16