### PR TITLE
Prevent signature tag cancellation from changing editor mode

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1765,17 +1765,24 @@ const App = () => {
 		});
 	};
 
-	const completeAddingSignatureFromTag = async ({signatureImageUrl, details}) => {
-		const { naturalWidth, naturalHeight } = await loadImage(signatureImageUrl);
-		const targetHeight = details.source.height;
-		const aspectRatio = naturalWidth / naturalHeight;
-    const calculatedWidth = targetHeight * aspectRatio;
+        const completeAddingSignatureFromTag = async ({signatureImageUrl, details}) => {
+                const { naturalWidth, naturalHeight } = await loadImage(signatureImageUrl);
+                const targetHeight = details.source.height;
+                const aspectRatio = naturalWidth / naturalHeight;
+                const calculatedWidth = targetHeight * aspectRatio;
 
-		const payload = {
-			id: details.id,
-			pageNumber: details.source.pageIndex + 1,
-			pageIndex: details.source.pageIndex,
-			bitmapUrl: signatureImageUrl,
+                isManuallyAddingImageRef.current = true;
+                pdfViewerRef.current.annotationEditorMode = {
+                        isFromKeyboard: false,
+                        mode: pdfjs.AnnotationEditorType.STAMP,
+                        source: null
+                };
+
+                const payload = {
+                        id: details.id,
+                        pageNumber: details.source.pageIndex + 1,
+                        pageIndex: details.source.pageIndex,
+                        bitmapUrl: signatureImageUrl,
 			initialWidth: calculatedWidth,
 			initialHeight: targetHeight,
 			initialX: details.x + (details.source.width / 2),
@@ -1841,12 +1848,6 @@ const App = () => {
 	}
 
         const handleSignTagClicked = async (details) => {
-                isManuallyAddingImageRef.current = true;
-                pdfViewerRef.current.annotationEditorMode = {
-                        isFromKeyboard: false,
-                        mode: pdfjs.AnnotationEditorType.STAMP,
-                        source: null
-                };
                 if (fullSignature) {
                         completeAddingSignatureFromTag({
                                 signatureImageUrl: fullSignature,


### PR DESCRIPTION
## Summary
- set the stamp editor mode only when completing signature placement so canceling the modal leaves the viewer in click-tag mode
- move the manual signature flag assignment to the placement flow to keep the clickable tag available after closing the modal

## Testing
- npm test -- --watch=false *(fails: missing npm script)*
- npm run lint *(fails: existing lint violations across the repo)*

------
https://chatgpt.com/codex/tasks/task_e_68d85c269b5c83238f7a814056226b57