### PR TITLE
Remove tag overlays after placing text fields

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1932,6 +1932,7 @@ const App = () => {
                         type: AnnotationEditorParamsType.CREATE,
                         value: payload
                 };
+                details.source?.remove();
                 if (editorMode === 'click-tag') {
                         pdfViewerRef.current.annotationEditorMode = {
                                 isFromKeyboard: false,


### PR DESCRIPTION
## Summary
- remove text tag overlays after placing name, email, initials, and date annotations so they match signature handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9c362ff408323b5245117437381d7