### PR TITLE
Allow hiding undo redo buttons via host message

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -383,7 +383,8 @@ const App = () => {
 
 	const [activePage, setActivePage] = useState(1);
 
-	const [tools, setTools] = useState([]);
+        const [tools, setTools] = useState([]);
+        const [hideUndoRedoButtons, setHideUndoRedoButtons] = useState(false);
 
 
 	useEffect(() => {
@@ -548,9 +549,12 @@ const App = () => {
                         if (typeof event.data === 'object' && event.data.files?.length) {
                                 addInitialFiles(event);
                         }
-			if (typeof event.data === 'object' && event.data.tools) {
-				setTools(event.data.tools);
-			}
+                        if (typeof event.data === 'object' && event.data.tools) {
+                                setTools(event.data.tools);
+                        }
+                        if (typeof event.data === 'object' && typeof event.data.hideUndoRedoButtons !== 'undefined') {
+                                setHideUndoRedoButtons(Boolean(event.data.hideUndoRedoButtons));
+                        }
 			if (typeof event.data === 'object' && event.data.locale) {
 				onChangeLocale(event.data.locale);
 			}
@@ -2459,6 +2463,7 @@ const App = () => {
                                                 expandedViewThumbnailScale={expandedViewThumbnailScale}
                                                 setMultiPageSelections={setMultiPageSelections}
                                                 multiPageSelections={multiPageSelections}
+                                                hideUndoRedoButtons={hideUndoRedoButtons}
                                                 showFullScreenThumbnails={shouldShowFullScreenThumbnails()}
                                                 onMinimize={onMinimize}
                                                 undoLastAction={undoLastAction}

--- a/src/Subheader/index.js
+++ b/src/Subheader/index.js
@@ -127,7 +127,8 @@ const Subheader = ({
         fontItalic,
         showApplyDocumentChanges,
         onApplyDocumentChanges,
-        isApplyingDocumentChanges
+        isApplyingDocumentChanges,
+        hideUndoRedoButtons = false
 }) => {
 
         const { t } = useTranslation();
@@ -145,7 +146,7 @@ const Subheader = ({
 		return length;
 	};
 
-	const showUndoRedo = () => !!tools?.editing?.length;
+        const showUndoRedo = () => !hideUndoRedoButtons && !!tools?.editing?.length;
 
 	const showExtract = () => {
 		if (annotationMode === pdfjs.AnnotationEditorType.FREETEXT


### PR DESCRIPTION
## Summary
- listen for host messages that request undo/redo buttons to be hidden
- plumb the visibility flag into the subheader so the buttons are omitted when requested

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5d63f6e708323b2775a07e6b1deab